### PR TITLE
Fix Unhandled Promise Rejection

### DIFF
--- a/lib/advertise/stop-advert.js
+++ b/lib/advertise/stop-advert.js
@@ -5,19 +5,28 @@ var broadcastAdvert = require('./broadcast-advert')
 var notify = require('../commands/notify')
 
 const stopAdvert = (ssdp, plumbing, advert) => {
-  clearTimeout(plumbing.timeout)
+    clearTimeout(plumbing.timeout)
 
-  // remove advert from list
-  var index = adverts.indexOf(advert)
-  adverts.splice(index, 1)
+    // remove advert from list
+    var index = adverts.indexOf(advert)
+    adverts.splice(index, 1)
 
-  // stop location servers
-  return Promise.all(
-    plumbing.shutDownServers()
-  )
-  .then(() => {
-    broadcastAdvert(ssdp, advert, notify.BYEBYE)
-  })
+
+    var shutdown;
+
+    if (plumbing.shutDownServers) {
+        shutdown = Promise.all(
+            plumbing.shutDownServers()
+        )
+    }
+    else {
+        shutdown = Promise.resolve();       // when we are being hosted by express, etc, don't shut the server down here.
+    }
+
+    // stop location servers
+    return shutdown.then(() => {
+        broadcastAdvert(ssdp, advert, notify.BYEBYE)
+    })
 }
 
 module.exports = stopAdvert


### PR DESCRIPTION
If bus.stop() is called when ssdp is hosted in eg. express, an unhandled promise rejection is thrown because plumbing.shutdownServers is undefined. Fix this by checking whether shutdownServers is defined before calling it.