### PR TITLE
USN field mismatch in Advertisement vs Search Response

### DIFF
--- a/lib/advertise/broadcast-advert.js
+++ b/lib/advertise/broadcast-advert.js
@@ -4,7 +4,7 @@ const broadcastAdvert = (ssdp, advert, notifcationSubType) => {
   ssdp.emit('ssdp:send-message', 'NOTIFY * HTTP/1.1', {
     'NT': advert.usn,
     'NTS': notifcationSubType,
-    'USN': advert.usn + '::' + ssdp.udn,
+    'USN': ssdp.udn + '::' + advert.usn,
     'CACHE-CONTROL': 'max-age=' + parseInt(advert.ttl / 1000, 10),
     'SERVER': ssdp.options.signature,
     'LOCATION': advert.location


### PR DESCRIPTION
The UUID and UDN components of the USN are swapped in the advertisement packet. Swap UUID and UDN components in broadcast USN to match spec. See http://www.upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.1.pdf, page 20