### PR TITLE
fix: rename usn to udn

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ import ssdp from '@achingbrain/ssdp'
 
 // all arguments are optional
 var bus = ssdp({
-  usn: 'unique-identifier', // defaults to a random UUID
+  udn: 'unique-identifier', // defaults to a random UUID
   // a string to identify the server by
   signature: 'node.js/0.12.6 UPnP/1.1 @achingbrain/ssdp/1.0.0',
   retry {

--- a/src/advertise/broadcast-advert.ts
+++ b/src/advertise/broadcast-advert.ts
@@ -5,7 +5,7 @@ export const broadcastAdvert = (ssdp: SSDP, advert: Advert, notifcationSubType: 
   ssdp.emit('ssdp:send-message', 'NOTIFY * HTTP/1.1', {
     NT: advert.usn,
     NTS: notifcationSubType,
-    USN: `${ssdp.usn}::${advert.usn}`,
+    USN: `${ssdp.udn}::${advert.usn}`,
     'CACHE-CONTROL': `max-age=${Math.round(advert.ttl / 1000)}`,
     SERVER: ssdp.signature,
     LOCATION: advert.location

--- a/src/advertise/parse-options.ts
+++ b/src/advertise/parse-options.ts
@@ -38,7 +38,7 @@ export function parseAdvertOptions (ssdp: SSDP, options: Advertisment): Advert {
         modelNumber: 'A vendor specific model number',
         modelURL: 'http://example.com',
         serialNumber: 'A device specific serial number',
-        UDN: ssdp.usn,
+        UDN: ssdp.udn,
         presentationURL: 'index.html'
       }
     }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -10,7 +10,7 @@ export function search (ssdp: SSDP, message: SearchMessage, remote: NetworkAddre
     if (message.ST === 'ssdp:all' || advert.usn.toLowerCase() === message.ST.toLowerCase()) {
       ssdp.emit('ssdp:send-message', 'HTTP/1.1 200 OK', {
         ST: message.ST === 'ssdp:all' ? advert.usn : message.ST,
-        USN: `${ssdp.usn}::${advert.usn}`,
+        USN: `${ssdp.udn}::${advert.usn}`,
         LOCATION: advert.location,
         'CACHE-CONTROL': `max-age=${Math.round(advert.ttl / 1000)}`,
         DATE: new Date().toUTCString(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export interface SSDPSocketOptions {
 }
 
 export interface SSDPOptions {
-  usn: string
+  udn: string
   signature: string
   sockets: SSDPSocketOptions[]
 }
@@ -80,9 +80,24 @@ export interface Advertisment {
 }
 
 export interface SSDP {
-  usn: string
+  /**
+   * Unique device name - identifies the device and must the same over time for a specific device instance
+   */
+  udn: string
+
+  /**
+   * A user-agent style string to identify the implementation
+   */
   signature: string
+
+  /**
+   * Currently open sockets
+   */
   sockets: SSDPSocket[]
+
+  /**
+   * Options passed to the constructor
+   */
   options: SSDPOptions
 
   start: () => Promise<void>
@@ -107,7 +122,7 @@ export interface SSDP {
 }
 
 class SSDPImpl extends EventEmitter implements SSDP {
-  public usn: string
+  public udn: string
   public signature: string
   public sockets: SSDPSocket[]
   public readonly options: SSDPOptions
@@ -116,7 +131,7 @@ class SSDPImpl extends EventEmitter implements SSDP {
     super()
 
     this.options = defaultSsdpOptions(options)
-    this.usn = this.options.usn
+    this.udn = this.options.udn
     this.signature = this.options.signature
     this.sockets = []
   }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -217,7 +217,7 @@ describe('ssdp', () => {
     bus.emit('transport:incoming-message', Buffer.from(searchMessage), searcher)
 
     const { message, remote } = await deferred.promise
-    expect(message).to.contain('USN: ' + bus.usn + '::my-service-type')
+    expect(message).to.contain('USN: ' + bus.udn + '::my-service-type')
     expect(message).to.contain('ST: my-service-type')
     expect(message).to.contain('LOCATION: http://')
     expect(remote).to.deep.equal(searcher)
@@ -264,7 +264,7 @@ describe('ssdp', () => {
     bus.emit('transport:incoming-message', Buffer.from(searchMessage), searcher)
 
     const { message, remote } = await deferred.promise
-    expect(message).to.contain('USN: ' + bus.usn + '::my-service-type')
+    expect(message).to.contain('USN: ' + bus.udn + '::my-service-type')
     expect(message).to.contain('ST: my-service-type')
     expect(message).to.contain('LOCATION: http://')
     expect(remote).to.deep.equal(searcher)


### PR DESCRIPTION
The server should have a Unique Device Name not a Unique Service Name as per the uPnP spec.

BREAKING CHANGE: the `usn` constructor argument has been renamed to `udn`