### PR TITLE
fix: allow not starting ssdp bus

### DIFF
--- a/src/create-sockets.ts
+++ b/src/create-sockets.ts
@@ -1,13 +1,14 @@
 import { createSocket } from 'dgram'
 import type { SSDP, SSDPSocket } from './index.js'
 
-export async function createSockets (ssdp: SSDP): Promise<SSDPSocket[]> {
+export async function createSockets (ssdp: SSDP, signal: AbortSignal): Promise<SSDPSocket[]> {
   return await Promise.all(
     ssdp.options.sockets.map(async options => {
       return await new Promise<SSDPSocket>((resolve, reject) => {
         const socket = createSocket({
           type: options.type,
-          reuseAddr: true
+          reuseAddr: true,
+          signal: signal
         }, (buf, info) => {
           ssdp.emit('transport:incoming-message', buf, info)
         })


### PR DESCRIPTION
Sometimes you need a reference to the bus before startup - in order to cancel startup before it's finished, so add an option to not start the bus when creating it.