### PR TITLE
fix: add missing package.json to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "files": [
     "src",
     "dist/src",
+    "dist/package.json",
     "!dist/test",
     "!**/*.tsbuildinfo"
   ],

--- a/src/default-ssdp-options.ts
+++ b/src/default-ssdp-options.ts
@@ -7,7 +7,7 @@ import mergeOptions from 'merge-options'
 import type { SSDPOptions } from './index.js'
 
 const req = createRequire(import.meta.url)
-const pkg = req('../../package.json')
+const pkg = req('../package.json')
 
 const DEFAULT_SSDP_SIGNATURE = util.format('node.js/%s UPnP/1.1 %s/%s', process.version.substring(1), pkg.name, pkg.version)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "include": [
     "src",
-    "test"
+    "test",
+    "package.json"
   ]
 }


### PR DESCRIPTION
Required `package.json` is missing in the published package at the required path, see https://www.unpkg.com/browse/@achingbrain/ssdp@4.0.1/dist/.