### PR TITLE
Update default-ssdp-options.ts

### DIFF
--- a/src/default-ssdp-options.ts
+++ b/src/default-ssdp-options.ts
@@ -1,5 +1,5 @@
 
-import { webcrypto as crypto } from 'crypto' // remove when having crypto global
+import * as crypto from 'crypto' // remove when having crypto global
 import { createRequire } from 'module'
 import mergeOptions from 'merge-options'
 import { defaultSocketOptions } from './default-socket-options.js'


### PR DESCRIPTION
change import syntax to prevent the following error:

`./node_modules/@achingbrain/ssdp/dist/src/default-ssdp-options.js:13:17-34 - Error: export 'webcrypto' (imported as 'crypto') was not found in 'crypto' (possible exports: Cipher, Cipheriv, Decipher, Decipheriv, DiffieHellman, DiffieHellmanGroup, Hash, Hmac, Sign, Verify, constants, createCipher, createCipheriv, createCredentials, createDecipher, createDecipheriv, createDiffieHellman, createDiffieHellmanGroup, createECDH, createHash, createHmac, createSign, createVerify, getCiphers, getDiffieHellman, getHashes, listCiphers, pbkdf2, pbkdf2Sync, privateDecrypt, privateEncrypt, prng, pseudoRandomBytes, publicDecrypt, publicEncrypt, randomBytes, randomFill, randomFillSync, rng)`