### PR TITLE
fix: override advertisement details

### DIFF
--- a/src/advertise/parse-options.ts
+++ b/src/advertise/parse-options.ts
@@ -12,7 +12,7 @@ export function parseAdvertOptions (ssdp: SSDP, options: Advertisment): Advert {
     throw new Error('Advert should have a usn property')
   }
 
-  const opts: Advert = mergeOptions(options, {
+  const opts: Advert = mergeOptions({
     usn: options.usn,
     interval: 10000,
     ttl: 1800000,
@@ -42,7 +42,7 @@ export function parseAdvertOptions (ssdp: SSDP, options: Advertisment): Advert {
         presentationURL: 'index.html'
       }
     }
-  })
+  }, options)
 
   const details = opts.details
 

--- a/src/commands/notify.ts
+++ b/src/commands/notify.ts
@@ -1,11 +1,11 @@
 import { cache } from '../cache.js'
 import { resolveService } from './resolve-service.js'
-import type { NotfiyMessage, SSDP } from '../index.js'
+import type { NotifyMessage, SSDP } from '../index.js'
 
 export const ALIVE = 'ssdp:alive'
 export const BYEBYE = 'ssdp:byebye'
 
-export function notify (ssdp: SSDP, message: NotfiyMessage): void {
+export function notify (ssdp: SSDP, message: NotifyMessage): void {
   if (message.LOCATION == null || message.USN == null || message.NT == null || message.NTS == null) {
     return
   }

--- a/src/default-socket-options.ts
+++ b/src/default-socket-options.ts
@@ -2,7 +2,7 @@ import mergeOptions from 'merge-options'
 import type { SSDPSocketOptions } from './index.js'
 
 export function defaultSocketOptions (options?: Partial<SSDPSocketOptions>): SSDPSocketOptions {
-  return mergeOptions(options ?? {}, {
+  return mergeOptions({
     type: 'udp4', // or 'udp6'
     broadcast: {
       address: '239.255.255.250', // or 'FF02::C'
@@ -13,5 +13,5 @@ export function defaultSocketOptions (options?: Partial<SSDPSocketOptions>): SSD
       port: 1900
     },
     maxHops: 4
-  })
+  }, options)
 }

--- a/src/default-ssdp-options.ts
+++ b/src/default-ssdp-options.ts
@@ -10,7 +10,7 @@ const { name, version } = req('../../package.json')
 const DEFAULT_SSDP_SIGNATURE = `node.js/${process.version.substring(1)} UPnP/1.1 ${name}/${version}`
 
 export function defaultSsdpOptions (options?: Partial<SSDPOptions>): SSDPOptions {
-  return mergeOptions(options ?? {}, {
+  return mergeOptions({
     usn: `uuid:${crypto.randomUUID()}`, // eslint-disable-line @typescript-eslint/restrict-template-expressions
     signature: DEFAULT_SSDP_SIGNATURE,
     sockets: [{}].map(defaultSocketOptions),
@@ -18,5 +18,5 @@ export function defaultSsdpOptions (options?: Partial<SSDPOptions>): SSDPOptions
       times: 5,
       interval: 5000
     }
-  })
+  }, options)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,8 +76,42 @@ export interface Service<DeviceDescription = Record<string, any>> {
 }
 
 export interface Advertisment {
+  /**
+   * A unique service name for the advertisement
+   */
   usn: string
+
+  /**
+   * Advertisment details. Will be transformed into XML and should follow the
+   * urn:schemas-upnp-org:device-1-0 schema.
+   */
   details: Record<string, any> | (() => Promise<Record<string, any>>)
+
+  /**
+   * An optional amount in ms which is the frequency to advertise the service
+   */
+  interval?: number
+
+  /**
+   * An optional amount in ms which is how long the advert should be cached for
+   */
+  ttl?: number
+
+  /**
+   * Whether to broadcast the advert over IPv4 (default: true)
+   */
+  ipv4?: boolean
+
+  /**
+   * Whether to broadcast the advert over IPv6 (default: true)
+   */
+  ipv6?: boolean
+
+  /**
+   * Where the description document(s) are available - omit to have an http
+   * server automatically created
+   */
+  location?: { udp4: string, udp6: string }
 }
 
 export interface SSDP {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export interface SSDPSocket extends Socket {
   options: SSDPSocketOptions
 }
 
-export interface NotfiyMessage {
+export interface NotifyMessage {
   LOCATION: string
   USN: string
   NT: string
@@ -57,7 +57,7 @@ interface SSDPEvents {
   'transport:outgoing-message'(socket: SSDPSocket, buffer: Buffer, to: NetworkAddress): void
   'ssdp:send-message'(status: string, headers: Record<string, any>, to?: NetworkAddress): void
   'ssdp:m-search'(message: SearchMessage, from: NetworkAddress): void
-  'ssdp:notify'(message: NotfiyMessage, from: NetworkAddress): void
+  'ssdp:notify'(message: NotifyMessage, from: NetworkAddress): void
   'ssdp:search-response'(message: SearchMessage, from: NetworkAddress): void
 
   'service:discover'(service: Service): void

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -28,7 +28,7 @@ describe('ssdp', () => {
         type: 'udp4',
         maxHops: 4,
         broadcast: {
-          address: '0.0.0.0',
+          address: '239.255.255.250',
           port: busPort
         },
         bind: {


### PR DESCRIPTION
Merge the passed options into the advertisement instead of the other way round.

Fixes #49