### PR TITLE
feat: accept abort signal when discovering services

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "event-iterator": "^2.0.0",
     "freeport-promise": "^2.0.0",
     "merge-options": "^3.0.4",
-    "race-signal": "^1.1.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -141,9 +141,11 @@
     "docs": "aegir docs"
   },
   "dependencies": {
+    "abort-error": "^1.0.0",
     "event-iterator": "^2.0.0",
     "freeport-promise": "^2.0.0",
     "merge-options": "^3.0.4",
+    "race-signal": "^1.1.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -326,8 +326,8 @@
  * - [Xedecimal/node-ssdp](https://www.npmjs.com/package/ssdp) (no longer maintained)
  */
 
-import { AbortError } from 'abort-error'
 import { EventEmitter } from 'events'
+import { AbortError } from 'abort-error'
 import { EventIterator } from 'event-iterator'
 import { advertise } from './advertise/index.js'
 import { adverts } from './adverts.js'

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -401,8 +401,8 @@ describe('ssdp', () => {
     })
 
     await expect((async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       for await (const _ of stream) {
-        return
         controller.abort()
       }
     })()).to.eventually.be.rejected


### PR DESCRIPTION
Allow aborting from discovery early by passing an abort signal as well as breaking out of the loop.

This way we don't need to race signals against promises which can be expensive.