### PR TITLE
fix: SSDP discovery according to spec

### DIFF
--- a/src/discover/index.ts
+++ b/src/discover/index.ts
@@ -6,6 +6,6 @@ export function discover (ssdp: SSDP, serviceType?: string): void {
   ssdp.emit('ssdp:send-message', 'M-SEARCH * HTTP/1.1', {
     ST: serviceType,
     MAN: '"ssdp:discover"',
-    MX: 0
+    MX: 1
   })
 }

--- a/src/discover/index.ts
+++ b/src/discover/index.ts
@@ -5,7 +5,7 @@ export function discover (ssdp: SSDP, serviceType?: string): void {
 
   ssdp.emit('ssdp:send-message', 'M-SEARCH * HTTP/1.1', {
     ST: serviceType,
-    MAN: 'ssdp:discover',
+    MAN: '"ssdp:discover"',
     MX: 0
   })
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -325,7 +325,8 @@ describe('ssdp', () => {
 
     const message = await deferred.promise
     expect(message).to.contain('ST: ' + usn)
-    expect(message).to.contain('MAN: ssdp:discover')
+    expect(message).to.contain('MAN: "ssdp:discover"')
+    expect(message).to.contain('MX: 1')
   })
 
   it('should search for all services', async () => {
@@ -343,7 +344,8 @@ describe('ssdp', () => {
 
     const message = await deferred.promise
     expect(message).to.contain('ST: ssdp:all')
-    expect(message).to.contain('MAN: ssdp:discover')
+    expect(message).to.contain('MAN: "ssdp:discover"')
+    expect(message).to.contain('MX: 1')
   })
 
   it('should handle search responses', async () => {


### PR DESCRIPTION
- **fix: use double quotes for man header like in spec**
- **fix: set valid MX max wait value like in spec**


Fixes https://github.com/libp2p/js-libp2p/issues/3065
## Reference from spec

[Spec](https://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.0-20080424.pdf)
![Screenshot 2025-03-31 at 12 42 15 pm](https://github.com/user-attachments/assets/1eb0dd7a-aefc-4ae5-8296-a067c69c26f5)