### PR TITLE
fix: make options optional and deep merge options

### DIFF
--- a/src/create-sockets.ts
+++ b/src/create-sockets.ts
@@ -1,20 +1,21 @@
-import { createSocket } from 'dgram'
+import { createSocket } from 'node:dgram'
 import type { SSDP, SSDPSocket } from './index.js'
 
 export async function createSockets (ssdp: SSDP, signal: AbortSignal): Promise<SSDPSocket[]> {
   const sockets: SSDPSocket[] = []
 
   await Promise.allSettled(
-    ssdp.options.sockets.map(async options => {
+    (ssdp.options.sockets ?? []).map(async options => {
       return new Promise<void>((resolve, reject) => {
         const socket = createSocket({
-          type: options.type,
+          type: options.type ?? 'udp4',
+          ipv6Only: options.type === 'udp6',
           reuseAddr: true,
           signal
         }, (buf, info) => {
           ssdp.emit('transport:incoming-message', buf, info)
         })
-        socket.bind(options.bind.port, options.bind.address)
+        socket.bind(options.bind?.port, options.bind?.address)
         // @ts-expect-error .options is not a property of Socket
         socket.options = options
         socket.on('error', (err) => {
@@ -22,15 +23,21 @@ export async function createSockets (ssdp: SSDP, signal: AbortSignal): Promise<S
         })
         socket.on('listening', () => {
           try {
-            socket.addMembership(options.broadcast.address, socket.address().address)
             socket.setBroadcast(true)
-            socket.setMulticastTTL(options.maxHops)
+
+            if (options.broadcast?.address != null) {
+              socket.addMembership(options.broadcast.address, socket.address().address)
+            }
+
+            if (options.maxHops != null) {
+              socket.setMulticastTTL(options.maxHops)
+            }
 
             sockets.push(socket as SSDPSocket)
 
             resolve()
           } catch (error: any) {
-            error.message = `Adding membership ${options.broadcast.address} failed - ${error.message}`
+            error.message = `Adding membership ${options.broadcast?.address} failed - ${error.message}`
             reject(error)
           }
         })

--- a/src/default-socket-options.ts
+++ b/src/default-socket-options.ts
@@ -10,6 +10,7 @@ export function defaultSocketOptions (options?: Partial<SSDPSocketOptions>): SSD
       port: 1900
     },
     bind: {
+      address: options?.type === 'udp6' ? '::' : '0.0.0.0',
       port: 1900
     },
     maxHops: 4

--- a/src/default-socket-options.ts
+++ b/src/default-socket-options.ts
@@ -6,11 +6,10 @@ export function defaultSocketOptions (options?: Partial<SSDPSocketOptions>): SSD
   return mergeOptions({
     type: 'udp4', // or 'udp6'
     broadcast: {
-      address: '239.255.255.250', // or 'FF05::C'
+      address: options?.type === 'udp6' ? 'FF05::C' : '239.255.255.250',
       port: 1900
     },
     bind: {
-      address: '0.0.0.0', // or '0:0:0:0:0:0:0:0'
       port: 1900
     },
     maxHops: 4

--- a/src/default-socket-options.ts
+++ b/src/default-socket-options.ts
@@ -2,7 +2,7 @@
 import mergeOptions from 'merge-options'
 import type { SSDPSocketOptions } from './index.js'
 
-export function defaultSocketOptions (options?: Partial<SSDPSocketOptions>): SSDPSocketOptions {
+export function defaultSocketOptions (options?: SSDPSocketOptions): SSDPSocketOptions {
   return mergeOptions({
     type: 'udp4', // or 'udp6'
     broadcast: {

--- a/src/default-ssdp-options.ts
+++ b/src/default-ssdp-options.ts
@@ -1,24 +1,17 @@
-import { webcrypto as crypto } from 'crypto' // remove when having crypto global
-import { createRequire } from 'module'
 // @ts-expect-error https://github.com/schnittstabil/merge-options/pull/28
 import mergeOptions from 'merge-options'
 import { defaultSocketOptions } from './default-socket-options.js'
 import type { SSDPOptions } from './index.js'
 
-const req = createRequire(import.meta.url)
-const { name, version } = req('../../package.json')
-
-const DEFAULT_SSDP_SIGNATURE = `node.js/${process.version.substring(1)} UPnP/1.1 ${name}/${version}`
-
-export function defaultSsdpOptions (options?: Partial<SSDPOptions>): SSDPOptions {
+export function defaultSsdpOptions (options?: SSDPOptions): SSDPOptions {
   return mergeOptions({
-    usn: `uuid:${crypto.randomUUID()}`,
-    signature: DEFAULT_SSDP_SIGNATURE,
-    sockets: [{}].map(defaultSocketOptions),
     retry: {
       times: 5,
       interval: 5000
     },
     cache: true
-  }, options)
+  }, {
+    ...options,
+    sockets: (options?.sockets ?? [{}]).map(defaultSocketOptions)
+  })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -532,7 +532,7 @@ export interface SSDP {
   ): boolean
 }
 
-export default async function (options: Partial<SSDPOptions> = {}): Promise<SSDP> {
+export default async function (options: SSDPOptions = {}): Promise<SSDP> {
   const ssdp = new SSDPImpl(options)
 
   if (options.start !== false) {

--- a/src/send-ssdp-message.ts
+++ b/src/send-ssdp-message.ts
@@ -25,14 +25,14 @@ export function sendSsdpMessage (ssdp: SSDP, status: string, headers: Record<str
 
         if (!status.startsWith('HTTP/1.1')) {
           // not a response so insert the host header
-          let host = socket.options.broadcast.address
+          let host = socket.options.broadcast?.address
 
           if (socket.type === 'udp6') {
             // need to wrap IPv6 addrs in `[...]` because they can contain `:`
-            host = `[${socket.options.broadcast.address}]`
+            host = `[${socket.options.broadcast?.address}]`
           }
 
-          message.push(`HOST: ${host}:${socket.options.broadcast.port}`)
+          message.push(`HOST: ${host}:${socket.options.broadcast?.port}`)
         }
 
         Object.keys(headers).forEach(function (header) {

--- a/src/ssdp.ts
+++ b/src/ssdp.ts
@@ -25,7 +25,7 @@ export class SSDP extends EventEmitter implements SSDPInterface {
   public readonly options: SSDPOptions
   private readonly abortController: AbortController
 
-  constructor (options?: Partial<SSDPOptions>) {
+  constructor (options?: SSDPOptions) {
     super()
 
     this.options = defaultSsdpOptions(options)

--- a/src/ssdp.ts
+++ b/src/ssdp.ts
@@ -1,0 +1,91 @@
+import { EventEmitter, on } from 'node:events'
+import { createRequire } from 'node:module'
+import { advertise } from './advertise/index.js'
+import { adverts } from './adverts.js'
+import { notify } from './commands/notify.js'
+import { search } from './commands/search.js'
+import { createSockets } from './create-sockets.js'
+import { defaultSsdpOptions } from './default-ssdp-options.js'
+import { discover } from './discover/index.js'
+import { searchResponse } from './discover/search-response.js'
+import { parseSsdpMessage } from './parse-ssdp-message.js'
+import { sendSsdpMessage } from './send-ssdp-message.js'
+import type { CachedAdvert } from './adverts.js'
+import type { Advertisement, DiscoverOptions, Service, SSDP as SSDPInterface, SSDPOptions, SSDPSocket } from './index.js'
+
+const req = createRequire(import.meta.url)
+const { name, version } = req('../../package.json')
+
+const DEFAULT_SSDP_SIGNATURE = `node.js/${process.version.substring(1)} UPnP/1.1 ${name}/${version}`
+
+export class SSDP extends EventEmitter implements SSDPInterface {
+  public udn: string
+  public signature: string
+  public sockets: SSDPSocket[]
+  public readonly options: SSDPOptions
+  private readonly abortController: AbortController
+
+  constructor (options?: Partial<SSDPOptions>) {
+    super()
+
+    this.options = defaultSsdpOptions(options)
+    this.udn = this.options.udn ?? `uuid:${crypto.randomUUID()}`
+    this.signature = this.options.signature ?? DEFAULT_SSDP_SIGNATURE
+    this.sockets = []
+    this.abortController = new AbortController()
+  }
+
+  async start (): Promise<void> {
+    // set up UDP sockets listening for SSDP broadcasts
+    this.sockets = await createSockets(this, this.abortController.signal)
+
+    // set up protocol listeners
+    this.on('transport:incoming-message', parseSsdpMessage.bind(null, this))
+    this.on('ssdp:send-message', sendSsdpMessage.bind(null, this))
+    this.on('ssdp:m-search', search.bind(null, this))
+    this.on('ssdp:notify', notify.bind(null, this))
+    this.on('ssdp:search-response', searchResponse.bind(null, this))
+  }
+
+  async stop (): Promise<void> {
+    await adverts.stopAll()
+
+    await Promise.all(
+      this.sockets.map(async socket => {
+        await new Promise<void>(resolve => {
+          socket.on('close', () => { resolve() })
+          socket.close()
+          socket.closed = true
+        })
+      })
+    )
+
+    this.abortController.abort()
+  }
+
+  async advertise (advert: Advertisement): Promise<CachedAdvert> {
+    return advertise(this, advert)
+  }
+
+  async * discover <Details = Record<string, any>> (serviceType?: string | DiscoverOptions): AsyncGenerator<Service<Details>, void, any> {
+    const opts: DiscoverOptions | undefined = typeof serviceType === 'string' ? { serviceType } : serviceType
+
+    discover(this, opts?.serviceType)
+
+    let interval: ReturnType<typeof globalThis.setInterval> | undefined
+
+    if (opts?.searchInterval != null) {
+      interval = setInterval(() => {
+        discover(this, opts?.serviceType)
+      }, opts.searchInterval)
+    }
+
+    try {
+      for await (const [service] of on(this, 'service:discover', opts)) {
+        yield service
+      }
+    } finally {
+      clearInterval(interval)
+    }
+  }
+}

--- a/test/fixtures/all.ts
+++ b/test/fixtures/all.ts
@@ -20,5 +20,3 @@ export async function all (): Promise<void> {
     console.info(JSON.stringify(service.details, null, 2))
   }
 }
-
-// void all()


### PR DESCRIPTION
To allow passing partial configs, make all options properties optional.